### PR TITLE
Add support for mutual authentication via TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ Implemented and tested with Sonatype Nexus `3.64.0-03`.
 
 ```hcl
 provider "nexus" {
-  insecure = true
-  password = "admin123"
-  url      = "https://127.0.0.1:8080"
-  username = "admin"
+  insecure         = true
+  password         = "admin123"
+  url              = "https://127.0.0.1:8080"
+  username         = "admin"
+  client_cert_path = "/path/to/client.crt"
+  client_key_path  = "/path/to/client.key"
+  root_ca_path     = "/path/to/root_ca.crt"
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/stretchr/testify v1.9.0
 )
 
+replace github.com/datadrivers/go-nexus-client => github.com/octoenergy/go-nexus-client v1.12.0
+
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1 // indirect
 	4d63.com/gochecknoglobals v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,6 @@ github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53E
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/daixiang0/gci v0.13.4 h1:61UGkmpoAcxHM2hhNkZEf5SzwQtWJXTSws7jaPyqwlw=
 github.com/daixiang0/gci v0.13.4/go.mod h1:12etP2OniiIdP4q+kjUGrC/rUagga7ODbqsom5Eo5Yk=
-github.com/datadrivers/go-nexus-client v1.10.1 h1:FAQBkYOxlgh9wpaDiHpjAZ96EkMm5FVOKzJAFfTiCdw=
-github.com/datadrivers/go-nexus-client v1.10.1/go.mod h1:nYUmYplEgXusK5Hvz+stvslPbSgSO0MyidDy6Da4LO0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -521,6 +519,8 @@ github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
 github.com/nunnatsa/ginkgolinter v0.16.2 h1:8iLqHIZvN4fTLDC0Ke9tbSZVcyVHoBs0HIbnVSxfHJk=
 github.com/nunnatsa/ginkgolinter v0.16.2/go.mod h1:4tWRinDN1FeJgU+iJANW/kz7xKN5nYRAOfJDQUS9dOQ=
+github.com/octoenergy/go-nexus-client v1.12.0 h1:1BAoqxuxDRQ9LQnZ+vSHBN84vZASaqpt1quOo9laZqY=
+github.com/octoenergy/go-nexus-client v1.12.0/go.mod h1:sPjBOxF7idUoiJoa730L3JyKZodjT0LDAvVF8u4kOLU=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=

--- a/internal/provider/main.go
+++ b/internal/provider/main.go
@@ -178,6 +178,24 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Type:        schema.TypeInt,
 			},
+			"client_cert_path": {
+				Description: "Path to a client PEM certificate to load for mTLS. Reading environment variable NEXUS_CLIENT_CERT_PATH. Default:``",
+				DefaultFunc: schema.EnvDefaultFunc("NEXUS_CLIENT_CERT_PATH", ""),
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			"client_key_path": {
+				Description: "Path to a client PEM key to load for mTLS. Reading environment variable NEXUS_CLIENT_KEY_PATH. Default:``",
+				DefaultFunc: schema.EnvDefaultFunc("NEXUS_CLIENT_KEY_PATH", ""),
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			"root_ca_path": {
+				Description: "Path to a root CA certificate to load for mTLS. Reading environment variable NEXUS_ROOT_CA_PATH. Default:``",
+				DefaultFunc: schema.EnvDefaultFunc("NEXUS_ROOT_CA_PATH", ""),
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
 		},
 		ConfigureFunc: providerConfigure,
 	}
@@ -185,12 +203,18 @@ func Provider() *schema.Provider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	timeout := d.Get("timeout").(int)
+	clientCertPath := d.Get("client_cert_path").(string)
+	clientKeyPath := d.Get("client_key_path").(string)
+	rootCaPath := d.Get("root_ca_path").(string)
 	config := client.Config{
-		Insecure: d.Get("insecure").(bool),
-		Password: d.Get("password").(string),
-		URL:      d.Get("url").(string),
-		Username: d.Get("username").(string),
-		Timeout:  &timeout,
+		Insecure:              d.Get("insecure").(bool),
+		Password:              d.Get("password").(string),
+		URL:                   d.Get("url").(string),
+		Username:              d.Get("username").(string),
+		Timeout:               &timeout,
+		ClientCertificatePath: &clientCertPath,
+		ClientKeyPath:         &clientKeyPath,
+		RootCAPath:            &rootCaPath,
 	}
 
 	return nexus.NewClient(config), nil


### PR DESCRIPTION
Prior to this change, there was no way to pass in a client certificate if you had set up Nexus behind a load balancer with mutual auth configured.

This change exposes some new configuration values that allow you to pass in a path to a file on disk containing your client key/cert (which can be in a single file) and optionally a Root CA.